### PR TITLE
rkhunter - run `rkhunter --propupd` in case rkhunter.dat is missing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,11 @@
       line: "ALLOWDEVFILE=\"/dev/shm/network/ifstate\""
       state: present
 
+  - name: Antirootkits | rkhunter | run propupd
+    command: /usr/bin/rkhunter --propupd
+    args:
+      creates: /var/lib/rkhunter/db/rkhunter.dat
+
   when: antirootkits_rkhunter_enabled
   tags: [ 'rkhunter' ]
 


### PR DESCRIPTION
I noticed rkhunter.dat was missing after a fresh install on CentOS 8. This PR aims to ensure propupd has been performed at least once.

For reference, here is the warning from rkhunter logs:

```
[03:13:13] Warning: Checking for prerequisites               [ Warning ]
[03:13:13]          The file of stored file properties (rkhunter.dat) does not exist, and should be created. To do this type in 'rkhunter --propupd'.
[03:13:13] Info: The file properties check will still run as there are checks that can be performed without the 'rkhunter.dat' file.
[03:13:13]
[03:13:13] Warning: WARNING! It is the users responsibility to ensure that when the '--propupd' option
           is used, all the files on their system are known to be genuine, and installed from a
           reliable source. The rkhunter '--check' option will compare the current file properties
           against previously stored values, and report if any values differ. However, rkhunter
           cannot determine what has caused the change, that is for the user to do.
```