### PR TITLE
manage different implementation of the mail command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The role can be used to deploy only a few of all the supported tools:
 - **antirootkits_shelldetector_enabled**: wether to deploy shelldetector
 - **antirootkits_pkg_list**: list of packages to install (varies between Debian and RHEL)
 
+- **antirootkits_mail_cmd**: Command to send reports (varies between Debian and RHEL)
 - **antirootkits_mail_from**: Sender email address for the audit reports. No valid default, you have to fill it in.
 - **antirootkits_mail_to**: Receiver email address for the audit reports. No valid default, you have to fill it in.
 - **antirootkits_log_expire**: Days before logs are purged. Defaults to _'90'_.

--- a/templates/shelldetector.cron.j2
+++ b/templates/shelldetector.cron.j2
@@ -9,10 +9,10 @@ LOG_EXPIRE={{ antirootkits_log_expire }}
 
 FROM="{{ antirootkits_mail_from }}"
 TO="{{ antirootkits_mail_to }}"
+SUBJECT="${HOST}: Shell Detector audit (${DATE})"
 
 python /usr/local/bin/shelldetect.py -r True -d {{ shelldetector_scan_directory }} > ${REPORT}
 
 find $LOG_DIR -type f -mtime +$LOG_EXPIRE -delete -print
 
-echo "Shell Detector audit for ${HOST} on ${DATE}: ${REPORT}" |
-/usr/bin/mail -s "${HOST}: Shell Detector audit (${DATE})" -r ${FROM} -a ${REPORT} ${TO}
+echo "Shell Detector audit for ${HOST} on ${DATE}: ${REPORT}" | {{ antirootkits_mail_cmd }}

--- a/vars/defaults-Debian.yml
+++ b/vars/defaults-Debian.yml
@@ -10,3 +10,5 @@ antirootkits_rkhunter_enabled: true
 antirootkits_chkrootkit_enabled: true
 antirootkits_unhide_enabled: true
 antirootkits_shelldetector_enabled: true
+
+antirootkits_mail_cmd: '/usr/bin/mail -s "${SUBJECT}" -r ${FROM} -A ${REPORT} ${TO}'

--- a/vars/defaults-RedHat.yml
+++ b/vars/defaults-RedHat.yml
@@ -10,3 +10,4 @@ antirootkits_unhide_enabled: false
 antirootkits_shelldetector_enabled: true
 
 antirootkits_rkhunter_diag_scan: no
+antirootkits_mail_cmd: '/usr/bin/mail -s "${SUBJECT}" -r ${FROM} -a ${REPORT} ${TO}'


### PR DESCRIPTION
shelldector_cron.sh used to send reports as mail attachments using "-a" parameter of the mail command. Unfortunately, this varies from [one implementation](https://manpages.debian.org/buster/mailutils/mailx.1.en.html) to [another](https://linux.die.net/man/1/mailx).

This PR fixes the syntax for the mail command provided by mailutils on Debian. It also allows to override the command for whom would like to use a different implementation.

Please take your time, there is no rush ^^