### PR TITLE
Rkhunter : setup ALLOW_SSH_ROOT_USER from role

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The following variables control whether a tool is installed (*true*) or not (*fa
 - **shelldetector_cron_hour**: Hour of execution of Shell Detector's cron job. Defaults to _'6'_.
 - **shelldetector_cron_minute**: Minute of execution of Shell Detector's cron job. Defaults to _'30'_.
 
+### Rkhunter setup
+
+- **rkhunter_allow_ssh_root_user**: Define what rkhunter should expect in sshd config. Defaults to _'no'_.
+
 ## Example playbook
 
 Example of how to use this role:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,6 @@ shelldetector_scan_directory: '/var/www'
 shelldetector_log_directory: '/var/log/shelldetector'
 shelldetector_cron_hour: '6'
 shelldetector_cron_minute: '30'
+
+# Rkhunter setup
+rkhunter_allow_ssh_root_user: 'no'

--- a/tasks/rkhunter.yml
+++ b/tasks/rkhunter.yml
@@ -72,6 +72,13 @@
     line: "MAIL-ON-WARNING=\"{{ antirootkits_mail_to }}\""
     state: present
 
+- name: Rkhunter | setup attended root ssh access
+  lineinfile:
+    dest: "/etc/rkhunter.conf"
+    regexp: "^ALLOW_SSH_ROOT_USER="
+    line: "ALLOW_SSH_ROOT_USER==\"{{ rkhunter_allow_ssh_root_user }}\""
+    state: present
+
 - name: Rkhunter | whitelist /dev/shm/network/ifstate
   lineinfile:
     dest: "/etc/rkhunter.conf"

--- a/tasks/rkhunter.yml
+++ b/tasks/rkhunter.yml
@@ -76,7 +76,7 @@
   lineinfile:
     dest: "/etc/rkhunter.conf"
     regexp: "^ALLOW_SSH_ROOT_USER="
-    line: "ALLOW_SSH_ROOT_USER==\"{{ rkhunter_allow_ssh_root_user }}\""
+    line: "ALLOW_SSH_ROOT_USER={{ rkhunter_allow_ssh_root_user }}"
     state: present
 
 - name: Rkhunter | whitelist /dev/shm/network/ifstate


### PR DESCRIPTION
Hi,

Sometimes, we need to allow root to log in.
I enhanced rkhunter setup to reflect this by setting the appropriate configuration at deployment time.
The default is set to no, as it is in default packages ( Redhat, CentOS and Debian ).

It is tested on CentOS 8 and Debian 11.
I may rework this if needed.

Best regards,
Clément
